### PR TITLE
Adding initial function representation

### DIFF
--- a/Functions/Absolute.cs
+++ b/Functions/Absolute.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Functions;
+
+/// <summary>
+/// Absolute value (`|x|`).
+/// </summary>
+public record Absolute(IFunctionAST Inner) : IFunctionAST
+{
+    public double Evaluate(EvalContext ctx) => Math.Abs(Inner.Evaluate(ctx));
+}

--- a/Functions/Add.cs
+++ b/Functions/Add.cs
@@ -1,0 +1,9 @@
+namespace Functions;
+
+/// <summary>
+/// Addition in a function.
+/// </summary>
+public record Add(IFunctionAST Left, IFunctionAST Right) : IFunctionAST
+{
+    public double Evaluate(EvalContext ctx) => Left.Evaluate(ctx) + Right.Evaluate(ctx);
+}

--- a/Functions/Ceil.cs
+++ b/Functions/Ceil.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Functions;
+
+/// <summary>
+/// Ceil. Rounds a number up to the nearest integer.
+/// </summary>
+public record Ceil(IFunctionAST Inner) : IFunctionAST
+{
+    public double Evaluate(EvalContext ctx) => Math.Ceiling(Inner.Evaluate(ctx));
+}

--- a/Functions/Cosine.cs
+++ b/Functions/Cosine.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Functions;
+
+/// <summary>
+/// Cosine function.
+/// </summary>
+public record Cosine(IFunctionAST Inner) : IFunctionAST
+{
+    public double Evaluate(EvalContext ctx) => Math.Cos(Inner.Evaluate(ctx));
+}

--- a/Functions/Divide.cs
+++ b/Functions/Divide.cs
@@ -1,0 +1,9 @@
+namespace Functions;
+
+/// <summary>
+/// Division in a function.
+/// </summary>
+public record Divide(IFunctionAST Left, IFunctionAST Right) : IFunctionAST
+{
+    public double Evaluate(EvalContext ctx) => Left.Evaluate(ctx) / Right.Evaluate(ctx);
+}

--- a/Functions/EvalContext.cs
+++ b/Functions/EvalContext.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace Functions;
+
+/// <summary>
+/// Context useful for evaluating a function's AST. 
+/// Contains:
+/// - The value of all variables at this evaluation
+/// </summary>
+public class EvalContext
+{
+    public Dictionary<string, double> Variables { get; set; }
+}

--- a/Functions/Exponent.cs
+++ b/Functions/Exponent.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Functions;
+
+/// <summary>
+/// Sine function.
+/// </summary>
+public record Exponent(IFunctionAST Base, IFunctionAST Power) : IFunctionAST
+{
+    public double Evaluate(EvalContext ctx) => Math.Pow(Base.Evaluate(ctx), Power.Evaluate(ctx));
+}

--- a/Functions/Floor.cs
+++ b/Functions/Floor.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Functions;
+
+/// <summary>
+/// Floor. Rounds a number down to the nearest integer.
+/// </summary>
+public record Floor(IFunctionAST Inner) : IFunctionAST
+{
+    public double Evaluate(EvalContext ctx) => Math.Floor(Inner.Evaluate(ctx));
+}

--- a/Functions/IFunctionAST.cs
+++ b/Functions/IFunctionAST.cs
@@ -16,4 +16,6 @@ public interface IFunctionAST
     /// <param name="ctx">Evaluation context.</param>
     /// <returns>The value of this node.</returns>
     public double Evaluate(EvalContext ctx);
+
+    public double EvaluateAtT(double t) => Evaluate(new() { Variables = new() { { "t", t } } });
 }

--- a/Functions/IFunctionAST.cs
+++ b/Functions/IFunctionAST.cs
@@ -1,0 +1,19 @@
+namespace Functions;
+
+/// <summary>
+/// Interface for representing abstract syntax tree nodes for functions.
+/// </summary>
+public interface IFunctionAST
+{
+    /// <summary>
+    /// Get the value of this node of the AST.
+    /// This effectively "interprets" the AST, producing a final value when the top node is 
+    /// evaluated; it is also a recursive algorithm. 
+    /// 
+    /// May throw arbitrary exceptions depending on the AST's value. May return NaN, for example,
+    /// if a divide by 0 occurs.
+    /// </summary>
+    /// <param name="ctx">Evaluation context.</param>
+    /// <returns>The value of this node.</returns>
+    public double Evaluate(EvalContext ctx);
+}

--- a/Functions/IFunctionAST.cs
+++ b/Functions/IFunctionAST.cs
@@ -12,10 +12,21 @@ public interface IFunctionAST
     /// 
     /// May throw arbitrary exceptions depending on the AST's value. May return NaN, for example,
     /// if a divide by 0 occurs.
+    /// 
+    /// The supplied evaluation context should contain a value for every variable that is expected
+    /// to be referenced. 
     /// </summary>
-    /// <param name="ctx">Evaluation context.</param>
+    /// <param name="ctx">The environment to evaluate this function in.</param>
     /// <returns>The value of this node.</returns>
     public double Evaluate(EvalContext ctx);
 
+    /// <summary>
+    /// Calls `Evaluate()` where the evaluation context is only aware of the variable `t`.
+    /// 
+    /// May throw arbitrary exceptions depending on the AST's value. May return NaN, for example,
+    /// if a divide by 0 occurs.
+    /// </summary>
+    /// <param name="t">The value of `t`.</param>
+    /// <returns>The value of this node.</returns>
     public double EvaluateAtT(double t) => Evaluate(new() { Variables = new() { { "t", t } } });
 }

--- a/Functions/Multiply.cs
+++ b/Functions/Multiply.cs
@@ -1,0 +1,9 @@
+namespace Functions;
+
+/// <summary>
+/// Multiplication in a function.
+/// </summary>
+public record Multiply(IFunctionAST Left, IFunctionAST Right) : IFunctionAST
+{
+    public double Evaluate(EvalContext ctx) => Left.Evaluate(ctx) * Right.Evaluate(ctx);
+}

--- a/Functions/Number.cs
+++ b/Functions/Number.cs
@@ -1,0 +1,9 @@
+namespace Functions;
+
+/// <summary>
+/// A literal number in a function.
+/// </summary>
+public record Number(double Value) : IFunctionAST
+{
+    public double Evaluate(EvalContext ctx) => Value;
+}

--- a/Functions/Sine.cs
+++ b/Functions/Sine.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Functions;
+
+/// <summary>
+/// Sine function.
+/// </summary>
+public record Sine(IFunctionAST Inner) : IFunctionAST
+{
+    public double Evaluate(EvalContext ctx) => Math.Sin(Inner.Evaluate(ctx));
+}

--- a/Functions/Subtract.cs
+++ b/Functions/Subtract.cs
@@ -1,0 +1,9 @@
+namespace Functions;
+
+/// <summary>
+/// Subtraction in a function.
+/// </summary>
+public record Subtract(IFunctionAST Left, IFunctionAST Right) : IFunctionAST
+{
+    public double Evaluate(EvalContext ctx) => Left.Evaluate(ctx) - Right.Evaluate(ctx);
+}

--- a/Functions/Tangent.cs
+++ b/Functions/Tangent.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Functions;
+
+/// <summary>
+/// Tangent function.
+/// </summary>
+public record Tangent(IFunctionAST Inner) : IFunctionAST
+{
+    public double Evaluate(EvalContext ctx) => Math.Tan(Inner.Evaluate(ctx));
+}

--- a/Functions/Tests.cs
+++ b/Functions/Tests.cs
@@ -1,0 +1,40 @@
+using Xunit;
+
+namespace Functions.Tests;
+
+public class Tests
+{
+    [Theory]
+    [InlineData(0, 1)]
+    [InlineData(0.33, 1)]
+    [InlineData(2.26, 1)]
+    [InlineData(1.63, -1)]
+    [InlineData(-1.37, -1)]
+    public void SquareWave(double t, double output)
+    {
+        // 4floor(t) - 2floor(2t) + 1
+        // source: https://en.wikipedia.org/wiki/Square_wave
+        IFunctionAST f = new Add(
+            new Subtract(
+                new Multiply(
+                    new Number(4),
+                    new Floor(
+                        new Variable("t")
+                    )
+                ),
+                new Multiply(
+                    new Number(2),
+                    new Floor(
+                        new Multiply(
+                            new Number(2),
+                            new Variable("t")
+                        )
+                    )
+                )
+            ),
+            new Number(1)
+        );
+
+        Assert.Equal(f.EvaluateAtT(t), output);
+    }
+}

--- a/Functions/Variable.cs
+++ b/Functions/Variable.cs
@@ -1,0 +1,9 @@
+namespace Functions;
+
+/// <summary>
+/// Named variable in a function. Should probably only ever be `x`.
+/// </summary>
+public record Variable(string Name) : IFunctionAST
+{
+    public double Evaluate(EvalContext ctx) => ctx.Variables[Name];
+}

--- a/Functions/Variable.cs
+++ b/Functions/Variable.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Functions;
 
 /// <summary>
@@ -5,5 +7,27 @@ namespace Functions;
 /// </summary>
 public record Variable(string Name) : IFunctionAST
 {
-    public double Evaluate(EvalContext ctx) => ctx.Variables[Name];
+    public double Evaluate(EvalContext ctx)
+    {
+        if (ctx.Variables.TryGetValue(Name, out double value))
+            return value;
+        else
+            throw new UnboundVariableException() { Variable = Name };
+    }
+}
+
+/// <summary>
+/// Thrown when a variable in a function AST is evaluated without that variable being present in the 
+/// evaluation context. Make sure to add all relevant variables to the evaluation context before
+/// calling `IFunctionAST.Evaluate`.
+/// </summary>
+public class UnboundVariableException : Exception
+{
+    public string Variable { get; init; }
+
+    public UnboundVariableException() : base() { }
+
+    public UnboundVariableException(string message) : base(message) { }
+
+    public UnboundVariableException(string message, Exception inner) : base(message, inner) { }
 }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# SoundOfFunctions
+# SoundOfFunctions 
 Visualize sound with math!


### PR DESCRIPTION
Adds an AST data structure to represent variables (currently only `t` makes sense- but it's able to accept other variables if we find a use case), numbers, basic arithmetic, sin/cos/tan, floor/ceil, and absolute value. More can easily be added. 

Supports evaluation of these ASTs with one of 2 simple methods. 